### PR TITLE
feat: Allow --standard-libraries

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Set up Dafny
         uses: dafny-lang/setup-dafny-action@v1.8.0
         with:
-          dafny-version: "4.9.1"
+          # Using a nightly for now because --standard-libraries
+          # doesn't work without an unreleased fix
+          dafny-version: "nightly-2024-12-19-7df92c2"
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Dafny
         uses: dafny-lang/setup-dafny-action@v1.8.0
         with:
-          dafny-version: "4.9.0"
+          dafny-version: "4.9.1"
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,9 +20,9 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
       - name: Set up Dafny
-        uses: dafny-lang/setup-dafny-action@v1.6.1
+        uses: dafny-lang/setup-dafny-action@v1.8.0
         with:
-          dafny-version: "4.1.0"
+          dafny-version: "4.9.0"
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,10 @@
  */
 
 plugins {
-    // Apply the Java Gradle plugin development plugin to add support for developing Gradle plugins
-    `java-gradle-plugin`
+    // Apply the Plugin Publish plugin to make plugin publication possible
+    // The Plugin Publish plugin will in turn auto-apply the Gradle Plugin Development Plugin (java-gradle-plugin)
+    // and the Maven Publish plugin (maven-publish)
+    id("com.gradle.plugin-publish") version "1.2.0"
 
     `maven-publish`
 }
@@ -22,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.semver4j:semver4j:5.4.1")
     // Use JUnit Jupiter for testing.
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
 }

--- a/examples/multi-project-incompatible/consumer/build.gradle.kts
+++ b/examples/multi-project-incompatible/consumer/build.gradle.kts
@@ -5,12 +5,11 @@ plugins {
 dependencies {
     implementation(project(":producer"))
 
-    // TODO: Replace with 4.1.0 once released
-    implementation("org.dafny:DafnyRuntime:4.0.0")
+    implementation("org.dafny:DafnyRuntime:4.9.1")
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("unicode-char", true)
 }

--- a/examples/multi-project-incompatible/consumer/build.gradle.kts
+++ b/examples/multi-project-incompatible/consumer/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("unicode-char", true)
 }

--- a/examples/multi-project-incompatible/consumer/build.gradle.kts
+++ b/examples/multi-project-incompatible/consumer/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 dependencies {
     implementation(project(":producer"))
 
-    implementation("org.dafny:DafnyRuntime:4.9.1")
+    implementation("org.dafny:DafnyRuntime:4.9.0")
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 
     optionsMap.put("unicode-char", true)
 }

--- a/examples/multi-project-incompatible/producer/build.gradle.kts
+++ b/examples/multi-project-incompatible/producer/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("unicode-char", false)
 }

--- a/examples/multi-project-incompatible/producer/build.gradle.kts
+++ b/examples/multi-project-incompatible/producer/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.9.1")
+    implementation("org.dafny:DafnyRuntime:4.9.0")
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 
     optionsMap.put("unicode-char", false)
 }

--- a/examples/multi-project-incompatible/producer/build.gradle.kts
+++ b/examples/multi-project-incompatible/producer/build.gradle.kts
@@ -5,12 +5,11 @@ plugins {
 }
 
 dependencies {
-    // TODO: Replace with 4.1.0 once released
-    implementation("org.dafny:DafnyRuntime:4.0.0")
+    implementation("org.dafny:DafnyRuntime:4.9.1")
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("unicode-char", false)
 }

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -3,11 +3,11 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 }
 
 dependencies {
     implementation(project(":producer"))
 
-    implementation("org.dafny:DafnyRuntime:4.9.1")
+    implementation("org.dafny:DafnyRuntime:4.9.0")
 }

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 }
 
 dependencies {

--- a/examples/multi-project/consumer/build.gradle.kts
+++ b/examples/multi-project/consumer/build.gradle.kts
@@ -3,12 +3,11 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 }
 
 dependencies {
     implementation(project(":producer"))
 
-    // TODO: Replace with 4.1.0 once released
-    implementation("org.dafny:DafnyRuntime:4.0.0")
+    implementation("org.dafny:DafnyRuntime:4.9.1")
 }

--- a/examples/multi-project/producer/build.gradle.kts
+++ b/examples/multi-project/producer/build.gradle.kts
@@ -5,12 +5,11 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("function-syntax", 3)
 }
 
 dependencies {
-    // TODO: Replace with 4.1.0 once released
-    implementation("org.dafny:DafnyRuntime:4.0.0")
+    implementation("org.dafny:DafnyRuntime:4.9.1")
 }

--- a/examples/multi-project/producer/build.gradle.kts
+++ b/examples/multi-project/producer/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 
     optionsMap.put("function-syntax", 3)
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.9.1")
+    implementation("org.dafny:DafnyRuntime:4.9.0")
 }

--- a/examples/multi-project/producer/build.gradle.kts
+++ b/examples/multi-project/producer/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("function-syntax", 3)
 }

--- a/examples/no-dafny/build.gradle.kts
+++ b/examples/no-dafny/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 }

--- a/examples/no-dafny/build.gradle.kts
+++ b/examples/no-dafny/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 }

--- a/examples/no-dafny/build.gradle.kts
+++ b/examples/no-dafny/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 }

--- a/examples/simple-verify/build.gradle.kts
+++ b/examples/simple-verify/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 }

--- a/examples/simple-verify/build.gradle.kts
+++ b/examples/simple-verify/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 }

--- a/examples/simple-verify/build.gradle.kts
+++ b/examples/simple-verify/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.1.0")
+    dafnyVersion.set("4.9.1")
 }

--- a/examples/using-standard-libraries/build.gradle.kts
+++ b/examples/using-standard-libraries/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.1")
+    dafnyVersion.set("4.9.0")
 
     optionsMap.put("standard-libraries", true)
 }

--- a/examples/using-standard-libraries/build.gradle.kts
+++ b/examples/using-standard-libraries/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("org.dafny.dafny")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dafny {
+    dafnyVersion.set("4.9.1")
+
+    optionsMap.put("standard-libraries", true)
+}

--- a/examples/using-standard-libraries/build.gradle.kts
+++ b/examples/using-standard-libraries/build.gradle.kts
@@ -8,7 +8,11 @@ repositories {
 }
 
 dafny {
-    dafnyVersion.set("4.9.0")
+    dafnyVersion.set("4.9.1")
 
     optionsMap.put("standard-libraries", true)
+}
+
+dependencies {
+    implementation("org.dafny:DafnyRuntime:4.9.0")
 }

--- a/examples/using-standard-libraries/src/main/dafny/UsesStdLibs.dfy
+++ b/examples/using-standard-libraries/src/main/dafny/UsesStdLibs.dfy
@@ -1,0 +1,7 @@
+
+import opened Std.Wrappers
+import opened Std.Collections.Seq
+
+method Main() {
+  print IndexOfOption([1, 1, 2, 3, 5, 8, 13, 21], 5);
+}

--- a/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
@@ -76,4 +76,17 @@ class DafnyPluginFunctionalTest {
         Assertions.assertTrue(result.getOutput().contains(
                 "Incorrect Dafny version: expected 2.3.0, found"));
     }
+
+    // Regression test: this previously failed because the standard libraries
+    // end up included in the .doo file,
+    // so passing `--standard-libraries` again when translating led to duplicate definitions.
+    @Test void supportsStandardLibraries() throws IOException {
+        BuildResult result = GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments("clean", "build")
+                .withProjectDir(new File("examples/using-standard-libraries"))
+                .build();
+        Assertions.assertTrue(result.getOutput().contains("Some(4)"));
+    }
 }

--- a/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
@@ -37,7 +37,7 @@ class DafnyPluginFunctionalTest {
     }
 
     @Test void canReferenceDependencies() throws IOException {
-        BuildResult result = GradleRunner.create()
+        GradleRunner.create()
             .forwardOutput()
             .withPluginClasspath()
             .withArguments("clean", "build")
@@ -58,7 +58,7 @@ class DafnyPluginFunctionalTest {
     }
 
     @Test void succeedsWithNoDafnySourceFiles() throws IOException {
-        BuildResult result = GradleRunner.create()
+        GradleRunner.create()
             .forwardOutput()
             .withPluginClasspath()
             .withArguments("clean", "build")
@@ -80,13 +80,13 @@ class DafnyPluginFunctionalTest {
     // Regression test: this previously failed because the standard libraries
     // end up included in the .doo file,
     // so passing `--standard-libraries` again when translating led to duplicate definitions.
+    // Dafny has addressed this by not including the standard libraries which building .doo files.
     @Test void supportsStandardLibraries() throws IOException {
-        BuildResult result = GradleRunner.create()
+        GradleRunner.create()
                 .forwardOutput()
                 .withPluginClasspath()
                 .withArguments("clean", "build")
                 .withProjectDir(new File("examples/using-standard-libraries"))
                 .build();
-        Assertions.assertTrue(result.getOutput().contains("Some(4)"));
     }
 }

--- a/src/main/java/org/dafny/gradle/plugin/DafnyTranslateTask.java
+++ b/src/main/java/org/dafny/gradle/plugin/DafnyTranslateTask.java
@@ -9,7 +9,9 @@ import org.gradle.api.tasks.TaskAction;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public abstract class DafnyTranslateTask extends DafnyBaseTask {
 
@@ -32,7 +34,7 @@ public abstract class DafnyTranslateTask extends DafnyBaseTask {
         args.add("translate");
         args.add("java");
         args.add(dooFile.getPath());
-        args.addAll(Utils.getCommonArguments(getClasspath().get(), getOptions().get()));
+        args.addAll(Utils.getCommonArguments(getClasspath().get(), getOptionsForTranslate()));
 
         args.add("-o");
         args.add(outputDir.getPath());
@@ -42,5 +44,20 @@ public abstract class DafnyTranslateTask extends DafnyBaseTask {
         // Annoyingly, Dafny adds "-java" to the directory, so rename it
         File outputDirWithJava = new File(outputDir.getParentFile(), outputDir.getName() + "-java");
         outputDirWithJava.renameTo(outputDir);
+    }
+
+    private Map<String, Object> getOptionsForTranslate() {
+        // --standard-libraries needs special handling,
+        // since we first build a .doo file and then translate that.
+        // That means the standard library code is already in the source .doo file,
+        // and if we pass --standard-libraries against we end up with duplicate definitions.
+        //
+        // Note that there will also be options that can only be passed to `translate` and not `verify`.
+        // Rather than duplicate the metadata about which options apply to which command,
+        // we should generate a project file and pass it to Dafny,
+        // because then Dafny itself will select the applicable subset for us.
+        var options = new HashMap<>(getOptions().get());
+        options.remove("standard-libraries");
+        return options;
     }
 }

--- a/src/main/java/org/dafny/gradle/plugin/DafnyTranslateTask.java
+++ b/src/main/java/org/dafny/gradle/plugin/DafnyTranslateTask.java
@@ -34,7 +34,7 @@ public abstract class DafnyTranslateTask extends DafnyBaseTask {
         args.add("translate");
         args.add("java");
         args.add(dooFile.getPath());
-        args.addAll(Utils.getCommonArguments(getClasspath().get(), getOptionsForTranslate()));
+        args.addAll(Utils.getCommonArguments(getClasspath().get(), getOptions().get()));
 
         args.add("-o");
         args.add(outputDir.getPath());
@@ -44,20 +44,5 @@ public abstract class DafnyTranslateTask extends DafnyBaseTask {
         // Annoyingly, Dafny adds "-java" to the directory, so rename it
         File outputDirWithJava = new File(outputDir.getParentFile(), outputDir.getName() + "-java");
         outputDirWithJava.renameTo(outputDir);
-    }
-
-    private Map<String, Object> getOptionsForTranslate() {
-        // --standard-libraries needs special handling,
-        // since we first build a .doo file and then translate that.
-        // That means the standard library code is already in the source .doo file,
-        // and if we pass --standard-libraries against we end up with duplicate definitions.
-        //
-        // Note that there will also be options that can only be passed to `translate` and not `verify`.
-        // Rather than duplicate the metadata about which options apply to which command,
-        // we should generate a project file and pass it to Dafny,
-        // because then Dafny itself will select the applicable subset for us.
-        var options = new HashMap<>(getOptions().get());
-        options.remove("standard-libraries");
-        return options;
     }
 }

--- a/src/main/java/org/dafny/gradle/plugin/DafnyVersionCheckTask.java
+++ b/src/main/java/org/dafny/gradle/plugin/DafnyVersionCheckTask.java
@@ -4,6 +4,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.semver4j.Semver;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,9 +19,9 @@ public abstract class DafnyVersionCheckTask extends DafnyBaseTask {
         List<String> args = List.of("--version");
         DafnyCLIResult result = invokeDafnyCLI(args);
 
-        String expected = getRequiredVersion().get();
-        String actual = result.stdout().trim();
-        if (!expected.equals(actual)) {
+        Semver expected = Semver.parse(getRequiredVersion().get());
+        Semver actual = Semver.parse(result.stdout().trim());
+        if (!expected.isEquivalentTo(actual)) {
             throw new GradleException("Incorrect Dafny version: expected " + expected + ", found " + actual);
         }
     }


### PR DESCRIPTION
Resolves #11 

Needs https://github.com/dafny-lang/dafny/pull/5971, and as it turns out no other changes, so this PR just adds a regression test. It also updates the CI to use a Dafny nightly build with that fix. We should likely test against multiple Dafny versions in the future, but that will also require conditionally-enabled tests somehow.