### PR TITLE
Add new formatter / linter tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ dependencies {
 
 ## Documentation
 
-The plugin provides two tasks:
+The plugin provides four tasks, two of which are disabled by default:
 
 * `verifyDafny`, which verifes all Dafny code under the
   `src/main/dafny` directory.
+* `checkFormatDafny`, which fails if the formatting is incorrect (essentially a linter). Disabled by default.
+* `formatDafny`, which will re-format the source code. Disabled by default.
 * `translateDafnyToJava`, which translates Dafny code
   verified by `verifyDafny`
   to Java code, and ensures the result is also compiled
   together with the `main` Java source set.
 
-Both tasks are executed automatically as dependencies of tasks
+Enabled tasks are executed automatically as dependencies of tasks
 from the Java plugin, but can be executed manually as well.
 
 The plugin also embeds the built Dafny code in the resulting Jar file,
@@ -62,6 +64,14 @@ dafny {
 
 Note there is no support for different Dafny CLI options on a per-file basis.
 We recommend organizing Dafny source into subprojects with the same set of options instead.
+
+To enable one of the source code "format" tasks, for example the linter:
+
+```kotlin
+tasks.checkFormatDafny {
+  enabled = true
+}
+```
 
 ## Known Limitations
 

--- a/examples/bad-format/build.gradle.kts
+++ b/examples/bad-format/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("org.dafny.dafny")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dafny {
+    dafnyVersion.set("4.9.1")
+}
+
+ // Activate optional format *linter*
+tasks.checkFormatDafny {
+    enabled = true
+}

--- a/examples/bad-format/src/main/dafny/Foo.dfy
+++ b/examples/bad-format/src/main/dafny/Foo.dfy
@@ -1,0 +1,6 @@
+module Foo {
+  datatype Bar = Create(baz: string) {
+        // Wrong indentation
+                const x: string := baz
+  }
+}

--- a/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
+++ b/src/functionalTest/java/org/dafny/gradle/plugin/DafnyPluginFunctionalTest.java
@@ -124,4 +124,15 @@ class DafnyPluginFunctionalTest {
                 .build();
         Assertions.assertTrue(expected.lastModified() > firstTime);
     }
+
+    @Test
+    void failsOnBadFormat() throws IOException {
+        BuildResult result = GradleRunner.create()
+                .forwardOutput()
+                .withPluginClasspath()
+                .withArguments("clean", "checkFormatDafny")
+                .withProjectDir(new File("examples/bad-format"))
+                .buildAndFail();
+        Assertions.assertTrue(result.getOutput().contains("Foo.dfy needs to be formatted"));
+    }
 }

--- a/src/main/java/org/dafny/gradle/plugin/DafnyFormatTask.java
+++ b/src/main/java/org/dafny/gradle/plugin/DafnyFormatTask.java
@@ -1,0 +1,41 @@
+package org.dafny.gradle.plugin;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class DafnyFormatTask extends DafnyBaseTask {
+
+    @InputFiles
+    public abstract ConfigurableFileCollection getSourceFiles();
+
+    @Input
+    public abstract Property<Boolean> getIsCheck();
+
+    @TaskAction
+    public void format() throws IOException, InterruptedException {
+
+        if (getSourceFiles().isEmpty()) {
+            return;
+        }
+
+        List<String> args = new ArrayList<>();
+        args.add("format");
+        if (getIsCheck().getOrElse(false)) {
+            args.add("--check");
+        }
+        args.addAll(Utils.getCommonArguments(getClasspath().get(), getOptions().get()));
+        args.add("--");
+        for (var file : getSourceFiles().getFiles()) {
+            args.add(file.getPath());
+        }
+
+        invokeDafnyCLI(args);
+    }
+}


### PR DESCRIPTION
A new DafnyFormatTask is added that can run as either a passive checker / linter task "checkFormatDafny", or an active formatter task "formatDafny". Both are disabled by default.

Enabling the linter will fail a build on badly formatted source code, whereas enabling the formatter will ensure source is always correctly formatted prior to compilation.